### PR TITLE
dotenvファイルをloadするメソッドをfileパッケージに用意

### DIFF
--- a/app/controllers/config.go
+++ b/app/controllers/config.go
@@ -33,12 +33,12 @@ func (c Config) Confirm() revel.Result{
 func (c Config) Save() revel.Result {
 
 	// Formパラメータの取得
-	db 		 := c.Params.Form.Get("db")
-	host	 := c.Params.Form.Get("host")
-	port	 := c.Params.Form.Get("port")
-	dbuser	 := c.Params.Form.Get("dbuser")
-	dbname 	 := c.Params.Form.Get("dbname")
-	password := c.Params.Form.Get("password")
+	db 		 = c.Params.Form.Get("db")
+	host	 = c.Params.Form.Get("host")
+	port	 = c.Params.Form.Get("port")
+	dbuser	 = c.Params.Form.Get("dbuser")
+	dbname 	 = c.Params.Form.Get("dbname")
+	password = c.Params.Form.Get("password")
 
 	// バリデーション
 	c.Validation.Required(host)

--- a/app/service/file/file.go
+++ b/app/service/file/file.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"bufio"
 	"log"
+	"github.com/joho/godotenv"
 )
 
 type Handler struct{
@@ -23,4 +24,12 @@ func(h *Handler) CreateWriteFile(filename string, write_string string){
 		log.Fatal(werr)
 	}
 	bw.Flush()
+}
+
+// .envファイルの読み込み
+func(h *Handler) LoadEnv(){
+	err := godotenv.Load()
+	if err != nil{
+		log.Fatal("Error loading .env file")
+	}
 }

--- a/tests/configtest.go
+++ b/tests/configtest.go
@@ -3,11 +3,22 @@ package tests
 import(
 	"github.com/revel/revel/testing"
 	"net/url"
+	"sasuke/app/service/file"
+	"os"
 )
 
 type ConfigTest struct{
 	testing.TestSuite
 }
+
+var(
+	testdb		string
+	testhost	string
+	testport	string
+	testuser	string
+	testname	string
+	testpass	string
+)
 
 func (t *ConfigTest) Before(){}
 
@@ -20,16 +31,33 @@ func (t *ConfigTest) TestConfigPageWorks(){
 }
 
 func (t *ConfigTest) TestConfigPostFormSuccessData(){
+
+	testdb = "mysql"
+	testhost = "192.168.192.168"
+	testport = "3306"
+	testuser = "testuser"
+	testname = "testdb"
+	testpass = "P@ssw0rd"
+
 	configData := url.Values{}
-	configData.Add("db", "mysql")
-	configData.Add("host", "192.168.192.168")
-	configData.Add("port", "3306")
-	configData.Add("dbuser", "testuser")
-	configData.Add("dbname", "testdb")
-	configData.Add("password", "P@ssw0rd")
+	configData.Add("db", testdb)
+	configData.Add("host", testhost)
+	configData.Add("port", testport)
+	configData.Add("dbuser", testuser)
+	configData.Add("dbname", testdb)
+	configData.Add("password", testpass)
 
 	t.PostForm("/config/save", configData)
 
 	t.AssertOk()
 	t.AssertContentType("text/html; charset=utf-8")
+
+	f := &file.Handler{}
+	f.LoadEnv()
+	t.AssertEqual(testdb, os.Getenv("db"))
+	t.AssertEqual(testhost, os.Getenv("host"))
+	t.AssertEqual(testport, os.Getenv("port"))
+	t.AssertEqual(testuser, os.Getenv("dbuser"))
+	t.AssertEqual(testdb, os.Getenv("dbname"))
+	t.AssertEqual(testpass, os.Getenv("password"))
 }


### PR DESCRIPTION
dotenvファイルをloadするメソッドをfileパッケージ内に用意。
sql.go内ではこんな感じで呼び出せます。

```
f := &file.Handler{}
f.LoadEnv()

db 			:= os.Getenv("db")
host 		:= os.Getenv("host")
port 		:= os.Getenv("port")
dbuser 		:= os.Getenv("dbuser")
dbname 		:= os.Getenv("dbname")
password 	:= os.Getenv("password")
```